### PR TITLE
Development

### DIFF
--- a/circleguard/config.py
+++ b/circleguard/config.py
@@ -6,4 +6,4 @@ PATH_REPLAYS_STUB = PATH_ROOT / "replays"
 
 PATH_DB = PATH_ROOT / "db" / "cache.db" # /absolute/path/db/cache.db
 
-VERSION = "1.3.2d"
+VERSION = "1.3.3"

--- a/circleguard/config.py
+++ b/circleguard/config.py
@@ -6,4 +6,4 @@ PATH_REPLAYS_STUB = PATH_ROOT / "replays"
 
 PATH_DB = PATH_ROOT / "db" / "cache.db" # /absolute/path/db/cache.db
 
-VERSION = "1.3.2"
+VERSION = "1.3.2d"

--- a/circleguard/config.py
+++ b/circleguard/config.py
@@ -6,4 +6,4 @@ PATH_REPLAYS_STUB = PATH_ROOT / "replays"
 
 PATH_DB = PATH_ROOT / "db" / "cache.db" # /absolute/path/db/cache.db
 
-VERSION = "1.3.1d"
+VERSION = "1.3.2"


### PR DESCRIPTION
only load files that end in .osr, avoids hidden files causing issues. See #68