### PR TITLE
remove rare settings, move open settings to top

### DIFF
--- a/circleguard/gui.py
+++ b/circleguard/gui.py
@@ -951,6 +951,11 @@ class ScrollableSettingsWidget(QFrame):
         self.timer.timeout.connect(self.next_color)
         self.welcome = wizard.WelcomeWindow()
 
+        self.open_settings = ButtonWidget("Edit Settings File", "Open", "")
+        self.open_settings.button.clicked.connect(self._open_settings)
+        self.sync_settings = ButtonWidget("Sync Settings", "Sync", "")
+        self.sync_settings.button.clicked.connect(self._sync_settings)
+
         self.apikey_widget = LineEditSetting("Api Key", "", "password", "api_key")
         self.darkmode = OptionWidget("Dark mode", "Come join the dark side", "dark_theme")
         self.darkmode.box.stateChanged.connect(self.reload_theme)
@@ -964,12 +969,6 @@ class ScrollableSettingsWidget(QFrame):
         self.cache_location.path_signal.connect(partial(set_setting, "cache_dir"))
         self.cache.box.stateChanged.connect(self.cache_location.switch_enabled)
 
-        self.open_settings = ButtonWidget("Edit Settings File", "Open", "")
-        self.open_settings.button.clicked.connect(self._open_settings)
-
-        self.sync_settings = ButtonWidget("Sync Settings", "Sync", "")
-        self.sync_settings.button.clicked.connect(self._sync_settings)
-
         self.loglevel = LoglevelWidget("")
         self.loglevel.level_combobox.currentIndexChanged.connect(self.set_loglevel)
         self.set_loglevel() # set the default loglevel in cg, not just in gui
@@ -981,16 +980,14 @@ class ScrollableSettingsWidget(QFrame):
         self.wizard.button.clicked.connect(self.show_wizard)
 
         self.layout = QVBoxLayout()
+        self.layout.addWidget(self.open_settings)
+        self.layout.addWidget(self.sync_settings)
         self.layout.addWidget(Separator("General"))
         self.layout.addWidget(self.apikey_widget)
         self.layout.addWidget(self.cache)
-        self.layout.addWidget(self.cache_location)
-        self.layout.addWidget(self.open_settings)
-        self.layout.addWidget(self.sync_settings)
         self.layout.addWidget(Separator("Appearance"))
         self.layout.addWidget(self.darkmode)
         self.layout.addWidget(self.visualizer_info)
-        self.layout.addWidget(self.visualizer_frametime)
         self.layout.addWidget(self.visualizer_bg)
         self.layout.addWidget(self.visualizer_beatmap)
         self.layout.addWidget(Separator("Debug"))
@@ -1003,7 +1000,6 @@ class ScrollableSettingsWidget(QFrame):
 
         self.setLayout(self.layout)
 
-        self.cache_location.switch_enabled(get_setting("caching"))
         # we never actually set the theme to dark anywhere
         # (even if the setting is true), it should really be
         # in the main application but uh this works too

--- a/circleguard/gui.py
+++ b/circleguard/gui.py
@@ -929,8 +929,10 @@ class SettingsTab(QFrame):
 
 
         self.info = QLabel(self)
-        self.info.setText(f"circleguard v{__version__} | "
-                          f"circlecore v{cg_version} | "
+        # multiple spaces get shrinked to one space in rich text mode
+        # https://groups.google.com/forum/#!topic/qtcontribs/VDOQFUj-eIA
+        self.info.setText(f"circleguard v{__version__}&nbsp;&nbsp;|&nbsp;&nbsp;"
+                          f"circlecore v{cg_version}&nbsp;&nbsp;|&nbsp;&nbsp;"
                           f"<a href=\"https://github.com/circleguard/circleguard/issues\">Bug Report</a>")
         self.info.setTextFormat(Qt.RichText)
         self.info.setTextInteractionFlags(Qt.TextBrowserInteraction)

--- a/circleguard/gui.py
+++ b/circleguard/gui.py
@@ -16,7 +16,7 @@ import json
 
 from PyQt5.QtCore import Qt, QTimer, qInstallMessageHandler, QObject, pyqtSignal, QUrl
 from PyQt5.QtWidgets import (QWidget, QFrame, QTabWidget, QTextEdit, QPushButton, QLabel, QScrollArea, QFrame, QProgressBar,
-                             QVBoxLayout, QShortcut, QGridLayout, QApplication, QMainWindow, QSizePolicy, QComboBox)
+                             QVBoxLayout, QShortcut, QGridLayout, QApplication, QMainWindow, QSizePolicy, QComboBox, QSpacerItem)
 from PyQt5.QtGui import QPalette, QColor, QIcon, QKeySequence, QTextCursor, QPainter, QDesktopServices, QPixmap
 
 # app needs to be initialized before settings is imported so QStandardPaths resolves
@@ -979,20 +979,26 @@ class ScrollableSettingsWidget(QFrame):
         self.wizard = ButtonWidget("Run Wizard", "Run", "")
         self.wizard.button.clicked.connect(self.show_wizard)
 
+        vert_spacer = QSpacerItem(0, 10, QSizePolicy.Maximum, QSizePolicy.Minimum)
         self.layout = QVBoxLayout()
+        self.layout.setAlignment(Qt.AlignTop)
         self.layout.addWidget(self.open_settings)
         self.layout.addWidget(self.sync_settings)
+        self.layout.addItem(vert_spacer)
         self.layout.addWidget(Separator("General"))
         self.layout.addWidget(self.apikey_widget)
         self.layout.addWidget(self.cache)
+        self.layout.addItem(vert_spacer)
         self.layout.addWidget(Separator("Appearance"))
         self.layout.addWidget(self.darkmode)
         self.layout.addWidget(self.visualizer_info)
         self.layout.addWidget(self.visualizer_bg)
         self.layout.addWidget(self.visualizer_beatmap)
+        self.layout.addItem(vert_spacer)
         self.layout.addWidget(Separator("Debug"))
         self.layout.addWidget(self.loglevel)
         self.layout.addWidget(ResetSettings())
+        self.layout.addItem(vert_spacer)
         self.layout.addWidget(Separator("Dev"))
         self.layout.addWidget(self.rainbow)
         self.layout.addWidget(self.wizard)

--- a/circleguard/widgets.py
+++ b/circleguard/widgets.py
@@ -305,10 +305,6 @@ class LoglevelWidget(QFrame):
         level_combobox.setInsertPolicy(QComboBox.NoInsert)
         self.level_combobox = level_combobox
 
-        save_option = OptionWidget("Save logs?", "", "log_save", end="")
-        save_option.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
-        self.save_option = save_option
-
         output_combobox = QComboBox(self)
         output_combobox.setFixedWidth(100)
         output_combobox.addItem("NONE")
@@ -318,18 +314,12 @@ class LoglevelWidget(QFrame):
         output_combobox.setInsertPolicy(QComboBox.NoInsert)
         output_combobox.setCurrentIndex(0) # NONE by default
         self.output_combobox = output_combobox
-        self.save_folder = FolderChooser("Log Folder", get_setting("log_dir"))
-        save_option.box.stateChanged.connect(self.save_folder.switch_enabled)
-        self.save_folder.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
 
         self.level_combobox.setCurrentIndex(get_setting("log_mode"))
         self.level_combobox.currentIndexChanged.connect(partial(set_setting, "log_mode"))
 
         self.output_combobox.setCurrentIndex(get_setting("log_output"))
         self.output_combobox.currentIndexChanged.connect(partial(set_setting, "log_output"))
-
-        self.save_folder.switch_enabled(get_setting("log_save"))
-        self.save_folder.path_signal.connect(partial(set_setting, "log_dir"))
 
         self.layout = QGridLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)
@@ -339,8 +329,6 @@ class LoglevelWidget(QFrame):
         self.layout.addWidget(output_label, 1, 0, 1, 1)
         self.layout.addItem(SPACER, 1, 1, 1, 1)
         self.layout.addWidget(self.output_combobox, 1, 2, 1, 3, Qt.AlignRight)
-        self.layout.addWidget(save_option, 2, 0, 1, 5)
-        self.layout.addWidget(self.save_folder, 3, 0, 1, 5)
 
         self.setLayout(self.layout)
 


### PR DESCRIPTION
Removed some settings that I think were just cluttering up the Settings tab. They're still editable from the settings.cfg file of course.

Also gave some emphasis to being able to open the settings file by placing it at the top. Doesn't look great without a separator at the top, but i think that's just because I'm used to there being one there.