### PR TITLE
Keypress frames

### DIFF
--- a/circleguard/utils.py
+++ b/circleguard/utils.py
@@ -116,8 +116,8 @@ class Run():
 
 
 class Player:
-    def __init__(self, replay, cursor_color):
-        self.cursor_color = cursor_color
+    def __init__(self, replay, pen):
+        self.pen = pen
         self.username = replay.username
         self.t = replay.t
         # copy so we don't flip the actual replay's xy coordinates when we

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -99,7 +99,7 @@ class _Renderer(QFrame):
         for replay in replays:
             self.players.append(
                 Player(replay=replay,
-                       cursor_color=QPen(QColor().fromHslF(replays.index(replay) / self.replay_amount, 0.75, 0.5)),))
+                       pen=QPen(QColor().fromHslF(replays.index(replay) / self.replay_amount, 0.75, 0.5)),))
         self.playback_len = max(max(player.t) for player in self.players) if self.replay_amount > 0 else self.playback_len
         # flip all replays with hr
         for player in self.players:
@@ -248,11 +248,10 @@ class _Renderer(QFrame):
         Draws a cursor.
 
         Arguments:
-            QPainter painter: The painter.
-            Integer index: The index of the cursor to be drawn.
+            Player player: The index of the cursor to be drawn.
         """
         alpha_step = 1 / FRAMES_ON_SCREEN
-        _pen = player.cursor_color
+        _pen = player.pen
         _pen.setWidth(self.scaled_number(WIDTH_LINE))
         self.painter.setPen(_pen)
         for i in range(player.start_pos, player.end_pos):
@@ -288,15 +287,15 @@ class _Renderer(QFrame):
         if self.replay_amount > 0:
             for i in range(len(self.players)):
                 player = self.players[i]
-                p = player.cursor_color
+                pen = player.pen
                 self.painter.setPen(PEN_BLANK)
-                self.painter.setBrush(QBrush(p.color()))
+                self.painter.setBrush(QBrush(pen.color()))
                 self.painter.setOpacity(1 if Keys.M1 in Keys(int(player.k[player.end_pos])) else 0.3)
                 self.painter.drawRect(5, 27 - 9 + (11 * i), 10, 10)
                 self.painter.setOpacity(1 if Keys.M2 in Keys(int(player.k[player.end_pos])) else 0.3)
                 self.painter.drawRect(18, 27 - 9 + (11 * i), 10, 10)
                 self.painter.setOpacity(1)
-                self.painter.setPen(p)
+                self.painter.setPen(pen)
                 self.painter.drawText(31, 27 + (11 * i), f"{player.username} {player.mods.short_name()}: {int(player.xy[player.end_pos][0])}, {int(player.xy[player.end_pos][1])}")
             self.painter.setPen(PEN_WHITE)
             if self.replay_amount == 2:

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -381,8 +381,9 @@ class _Renderer(QFrame):
            List point: The X&Y position of the cross.
            Boolean grey_out: Whether to grey out the cross or not.
         """
-        prev_pen = self.painter.pen()
+        prev_pen = None
         if grey_out:
+            prev_pen = self.painter.pen()
             PEN_GREY_INACTIVE.setWidth(self.scaled_number(WIDTH_CROSS))
             self.painter.setPen(PEN_GREY_INACTIVE)
         half_width = LENGTH_CROSS/2

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -369,7 +369,6 @@ class _Renderer(QFrame):
         Draws a cross.
 
         Args:
-           QPainter painter: The painter.
            Float alpha: The alpha level from 0.0-1.0 to set the cross to.
            List point: The X&Y position of the cross.
         """

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -352,11 +352,10 @@ class _Renderer(QFrame):
 
     def draw_line(self, alpha, start, end):
         """
-        Draws a line using the given painter, pen, and alpha level from Point start to Point end.
+        Draws a line at the given alpha level from the start point to the end point.
 
         Arguments:
-            QPainter painter: The painter.
-            Integer alpha: The alpha level from 0.0-1.0 to set the line to.
+            Float alpha: The alpha level from 0.0-1.0 to set the line to.
                            https://doc.qt.io/qt-5/qcolor.html#alpha-blended-drawing
             List start: The X&Y position of the start of the line.
             List end: The X&Y position of the end of the line.
@@ -371,7 +370,7 @@ class _Renderer(QFrame):
 
         Args:
            QPainter painter: The painter.
-           Integer alpha: The alpha level from 0.0-1.0 to set the cross to.
+           Float alpha: The alpha level from 0.0-1.0 to set the cross to.
            List point: The X&Y position of the cross.
         """
         half_width = WIDTH_CROSS/2

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -254,7 +254,7 @@ class _Renderer(QFrame):
         Draws a cursor.
 
         Arguments:
-            Player player: The index of the cursor to be drawn.
+            Player player: player to draw the cursor of.
         """
         alpha_step = 1 / FRAMES_ON_SCREEN
         pen = player.pen

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -269,7 +269,7 @@ class _Renderer(QFrame):
             alpha = (i - player.start_pos) * alpha_step
             xy = player.xy[i]
             k = player.k[i]
-            self.draw_cross(alpha, xy, grey_out = not bool(k), pen=pen)
+            self.draw_cross(alpha, xy, grey_out = not bool(k))
         # reset alpha
         self.painter.setOpacity(1)
 
@@ -372,7 +372,7 @@ class _Renderer(QFrame):
         self.painter.setOpacity(alpha)
         self.painter.drawLine(self.scaled_point(start[0], start[1]), self.scaled_point(end[0], end[1]))
 
-    def draw_cross(self, alpha, point, grey_out, pen):
+    def draw_cross(self, alpha, point, grey_out):
         """
         Draws a cross.
 
@@ -380,8 +380,8 @@ class _Renderer(QFrame):
            Float alpha: The alpha level from 0.0-1.0 to set the cross to.
            List point: The X&Y position of the cross.
            Boolean grey_out: Whether to grey out the cross or not.
-            QPen pen: the pen to revert back to after drawing caps.
         """
+        prev_pen = self.painter.pen()
         if grey_out:
             PEN_GREY_INACTIVE.setWidth(self.scaled_number(WIDTH_CROSS))
             self.painter.setPen(PEN_GREY_INACTIVE)
@@ -395,7 +395,8 @@ class _Renderer(QFrame):
 
         self.draw_line(alpha, [x1, y1], [x2, y2])
         self.draw_line(alpha, [x2, y1], [x1, y2])
-        self.painter.setPen(pen)
+        if grey_out:
+            self.painter.setPen(prev_pen)
 
 
     def draw_hitobject(self, hitobj):


### PR DESCRIPTION
some code cleanup, and makes non keypress frames greyed out. 

I used rgb(133, 125, 125) for the grey, across all players. I considered (and tried) a slightly different grey (varying the hue in hsv to represent different colors) for each player, but I couldn't tell them apart so I decided it wasn't worth it.

We switch the pen more than we need to if we have consecutive greyed out or active frames, but drawing first the greyed out then the active frames (or vice versa) makes frames which occur later in time appear below frames earlier in time, which is confusing. So I left it as is/