### PR TITLE
highlight snaps in visualizer

### DIFF
--- a/circleguard/gui.py
+++ b/circleguard/gui.py
@@ -267,7 +267,7 @@ class WindowWrapper(LinkableSetting, QMainWindow):
 
         result_widget = ResultW(label_text, result, replays)
         # set button signal connections (visualize and copy template to clipboard)
-        result_widget.button.clicked.connect(partial(self.main_window.main_tab.visualize, result_widget.replays, result_widget.replays[0].map_id))
+        result_widget.button.clicked.connect(partial(self.main_window.main_tab.visualize, result_widget.replays, result_widget.replays[0].map_id, result_widget.result))
         if template_text:
             result_widget.button_clipboard.clicked.connect(partial(self.copy_to_clipboard, template_text))
         else: # hide template button if there is no template
@@ -790,11 +790,14 @@ class MainTab(QFrame):
         except Empty:
             pass
 
-    def visualize(self, replays, beatmap_id=None):
+    def visualize(self, replays, beatmap_id, result):
         # only run one instance at a time
         if self.visualizer_window is not None:
             self.visualizer_window.close()
-        self.visualizer_window = VisualizerWindow(replays=replays, beatmap_id=beatmap_id)
+        snaps = []
+        if isinstance(result, CorrectionResult):
+            snaps = [snap.time for snap in result.snaps]
+        self.visualizer_window = VisualizerWindow(replays=replays, beatmap_id=beatmap_id, events=snaps)
         self.visualizer_window.show()
 
 

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -28,7 +28,7 @@ FRAMES_ON_SCREEN = 15  # how many frames for each replay to draw on screen at a 
 PEN_WHITE = QPen(QColor(200, 200, 200))
 PEN_GRAY = QPen(QColor(75, 75, 75))
 PEN_GREY_INACTIVE = QPen(QColor(133, 125, 125))
-PEN_HIGHLIGHT = QPen(QColor(230, 215, 115))
+PEN_HIGHLIGHT = QPen(QColor(230, 212, 92))
 PEN_BLANK = QPen(QColor(0, 0, 0, 0))
 
 BRUSH_WHITE = QBrush(QColor(200, 200, 200))

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -269,10 +269,10 @@ class _Renderer(QFrame):
             highlight = any((player.t[i + 1] in self.events, player.t[i] in self.events))
             if highlight:
                 self.painter.setPen(PEN_HIGHLIGHT)
-            else:
-                self.painter.setPen(pen)
             self.draw_line((i-player.start_pos) * alpha_step, (player.xy[i][0], player.xy[i][1]),
                            (player.xy[i + 1][0], player.xy[i + 1][1]))
+            if highlight:
+                self.painter.setPen(pen)
         pen.setWidth(self.scaled_number(WIDTH_CROSS))
         self.painter.setPen(pen)
         for i in range(player.start_pos, player.end_pos+1):

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -265,14 +265,17 @@ class _Renderer(QFrame):
         pen.setWidth(self.scaled_number(WIDTH_LINE))
         PEN_HIGHLIGHT.setWidth(self.scaled_number(WIDTH_LINE))
         self.painter.setPen(pen)
+        highlighted_pen = False
         for i in range(player.start_pos, player.end_pos):
             highlight = any((player.t[i + 1] in self.events, player.t[i] in self.events))
-            if highlight:
+            if highlight and not highlighted_pen:
                 self.painter.setPen(PEN_HIGHLIGHT)
+                highlighted_pen = True
+            elif not highlight and highlighted_pen:
+                self.painter.setPen(pen)
+                highlighted_pen = False
             self.draw_line((i-player.start_pos) * alpha_step, (player.xy[i][0], player.xy[i][1]),
                            (player.xy[i + 1][0], player.xy[i + 1][1]))
-            if highlight:
-                self.painter.setPen(pen)
         pen.setWidth(self.scaled_number(WIDTH_CROSS))
         self.painter.setPen(pen)
         for i in range(player.start_pos, player.end_pos+1):

--- a/circleguard/visualizer.py
+++ b/circleguard/visualizer.py
@@ -263,8 +263,14 @@ class _Renderer(QFrame):
         alpha_step = 1 / FRAMES_ON_SCREEN
         pen = player.pen
         pen.setWidth(self.scaled_number(WIDTH_LINE))
+        PEN_HIGHLIGHT.setWidth(self.scaled_number(WIDTH_LINE))
         self.painter.setPen(pen)
         for i in range(player.start_pos, player.end_pos):
+            highlight = any((player.t[i + 1] in self.events, player.t[i] in self.events))
+            if highlight:
+                self.painter.setPen(PEN_HIGHLIGHT)
+            else:
+                self.painter.setPen(pen)
             self.draw_line((i-player.start_pos) * alpha_step, (player.xy[i][0], player.xy[i][1]),
                            (player.xy[i + 1][0], player.xy[i + 1][1]))
         pen.setWidth(self.scaled_number(WIDTH_CROSS))


### PR DESCRIPTION
draw event crosses with rgb(230, 215, 115) instead of the cursor color. 

Not *super* happy with the gold color, but we can't use any shade of blue since that's our second cursor, and I don't think green would work since it's the third primary color so it would appear as a "third cursor" instead of a highlighted event