### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.7.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.7.7
 
     - name: Install dependencies
       run: |
@@ -45,10 +45,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.7.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.7.7
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Add files to draft release
 on: repository_dispatch
 
 jobs:
-  build_win:
+  build_win_x64:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -12,6 +12,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7.7
+        architecture: 'x64'
 
     - name: Install dependencies
       run: |
@@ -26,6 +27,36 @@ jobs:
     - name: Build x64
       run: |
         pyinstaller gui_win_x64.spec --noconfirm
+
+    - name: Update Release
+      uses: ncipollo/release-action@v1.6.1
+      with:
+        artifacts: "dist/*.zip"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        draft: true
+        allowUpdates: true
+        tag: ${{ github.event.client_payload.version }}
+
+  build_win_x86:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.7.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7.7
+        architecture: 'x86'
+
+    - name: Install dependencies
+      run: |
+        pip install wheel
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install build dependencies
+      run: |
+        pip install -r requirements_build_win.txt
 
     - name: Build x86
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         tag: ${{ github.event.client_payload.version }}
 
   build_mac:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,74 @@
+name: Add files to draft release
+
+on: repository_dispatch
+
+jobs:
+  build_win:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        pip install wheel
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install build dependencies
+      run: |
+        pip install -r requirements_build_win.txt
+
+    - name: Build x64
+      run: |
+        pyinstaller gui_win_x64.spec --noconfirm
+
+    - name: Build x86
+      run: |
+        pyinstaller gui_win_x86.spec --noconfirm
+
+    - name: Update Release
+      uses: ncipollo/release-action@v1.6.1
+      with:
+        artifacts: "dist/*.zip"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        draft: true
+        allowUpdates: true
+        tag: ${{ github.event.client_payload.version }}
+
+  build_mac:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        pip install wheel
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install build dependencies
+      run: |
+        pip install -r requirements_build_mac.txt
+
+    - name: Build
+      run: |
+        pyinstaller gui_mac.spec --noconfirm
+
+    - name: Update Release
+      uses: ncipollo/release-action@v1.6.1
+      with:
+        artifacts: "dist/*.zip"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        draft: true
+        allowUpdates: true
+        tag: ${{ github.event.client_payload.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.7
 
     - name: Install dependencies
       run: |
@@ -45,10 +45,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.7
 
     - name: Install dependencies
       run: |

--- a/gui_mac.spec
+++ b/gui_mac.spec
@@ -55,8 +55,9 @@ app = BUNDLE(exe,
        )
 
 print("Creating zip")
-os.chdir("./dist/")
 zipf = zipfile.ZipFile('./Circleguard_osx.app.zip', 'w', zipfile.ZIP_DEFLATED)
-zipdir('./', zipf)
+zipdir('./dist/', zipf)
 zipf.close()
+print("Moving zip")
+os.rename("./Circleguard_osx.app.zip", "./dist/Circleguard_osx.app.zip")
 print("Finished zip")

--- a/gui_mac.spec
+++ b/gui_mac.spec
@@ -7,15 +7,19 @@ import zipfile
 os.path.expanduser
 from circleguard import __version__ # circlecore version, not gui
 
-# https://stackoverflow.com/a/42056050
-def zipdir(path, ziph):
-    length = len(path)
 
-    # ziph is zipfile handle
+def zipdir(path, ziph, sub_folder=""):
+    length = len(path)
+    print(os.listdir(path))
     for root, dirs, files in os.walk(path):
         folder = root[length:] # path without "parent"
+        if sub_folder != "":
+            print(f"before{folder}")
+            folder = sub_folder + folder
+            print(f"after{folder}")
         for file in files:
             ziph.write(os.path.join(root, file), os.path.join(folder, file))
+
 
 # pyinstaller build
 a = Analysis(['circleguard/gui.py'],
@@ -56,7 +60,7 @@ app = BUNDLE(exe,
 
 print("Creating zip")
 zipf = zipfile.ZipFile('./Circleguard_osx.app.zip', 'w', zipfile.ZIP_DEFLATED)
-zipdir('./dist/', zipf)
+zipdir('./dist/Circleguard.app', zipf, "./Circleguard.app")
 zipf.close()
 print("Moving zip")
 os.rename("./Circleguard_osx.app.zip", "./dist/Circleguard_osx.app.zip")

--- a/gui_mac.spec
+++ b/gui_mac.spec
@@ -10,13 +10,10 @@ from circleguard import __version__ # circlecore version, not gui
 
 def zipdir(path, ziph, sub_folder=""):
     length = len(path)
-    print(os.listdir(path))
     for root, dirs, files in os.walk(path):
         folder = root[length:] # path without "parent"
         if sub_folder != "":
-            print(f"before{folder}")
             folder = sub_folder + folder
-            print(f"after{folder}")
         for file in files:
             ziph.write(os.path.join(root, file), os.path.join(folder, file))
 

--- a/gui_mac.spec
+++ b/gui_mac.spec
@@ -2,8 +2,22 @@
 
 block_cipher = None
 from os.path import expanduser
+import os
+import zipfile
 os.path.expanduser
 from circleguard import __version__ # circlecore version, not gui
+
+# https://stackoverflow.com/a/42056050
+def zipdir(path, ziph):
+    length = len(path)
+
+    # ziph is zipfile handle
+    for root, dirs, files in os.walk(path):
+        folder = root[length:] # path without "parent"
+        for file in files:
+            ziph.write(os.path.join(root, file), os.path.join(folder, file))
+
+# pyinstaller build
 a = Analysis(['circleguard/gui.py'],
              pathex=['.'],
              datas=[('circleguard/resources/','resources/'), ('circleguard/examples', 'examples/')],
@@ -39,3 +53,10 @@ app = BUNDLE(exe,
               'CFBundleShortVersionString': __version__
              }
        )
+
+print("Creating zip")
+os.chdir("./dist/")
+zipf = zipfile.ZipFile('./Circleguard_osx.app.zip', 'w', zipfile.ZIP_DEFLATED)
+zipdir('./Circleguard.app/', zipf)
+zipf.close()
+print("Finished zip")

--- a/gui_mac.spec
+++ b/gui_mac.spec
@@ -57,6 +57,6 @@ app = BUNDLE(exe,
 print("Creating zip")
 os.chdir("./dist/")
 zipf = zipfile.ZipFile('./Circleguard_osx.app.zip', 'w', zipfile.ZIP_DEFLATED)
-zipdir('./Circleguard.app/', zipf)
+zipdir('./', zipf)
 zipf.close()
 print("Finished zip")

--- a/gui_win_x64.spec
+++ b/gui_win_x64.spec
@@ -3,6 +3,7 @@
 block_cipher = None
 from os.path import *
 import sys
+import os
 import win32com.client
 import zipfile
 import PyInstaller.config
@@ -21,7 +22,7 @@ def zipdir(path, ziph):
 # pyinstaller build
 PyInstaller.config.CONF['distpath'] = "./dist/Circleguard_win_x64"
 a = Analysis(['circleguard/gui.py'],
-             pathex=['.', 'C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64', expanduser('~/AppData/Local/Programs/Python/Python37/')],
+             pathex=['.', 'C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64', os.path.dirname(sys.executable)],
              datas=[('circleguard/resources/','resources/'), ('circleguard/examples', 'examples/')],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
@@ -56,7 +57,7 @@ shortcut.Targetpath = abspath(abspath(".\dist\Circleguard_win_x64\Circleguard\Ci
 shortcut.save()
 
 print("Creating zip")
-os. chdir("./dist/")
+os.chdir("./dist/")
 zipf = zipfile.ZipFile('./Circleguard_win_x64.zip', 'w', zipfile.ZIP_DEFLATED)
 zipdir('./Circleguard_win_x64/', zipf)
 zipf.close()

--- a/gui_win_x86.spec
+++ b/gui_win_x86.spec
@@ -3,6 +3,7 @@
 block_cipher = None
 from os.path import *
 import sys
+import os
 import win32com.client
 import zipfile
 import PyInstaller.config
@@ -21,7 +22,7 @@ def zipdir(path, ziph):
 # pyinstaller build
 PyInstaller.config.CONF['distpath'] = "./dist/Circleguard_win_x86"
 a = Analysis(['circleguard/gui.py'],
-             pathex=['.', 'C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x86', expanduser('~/AppData/Local/Programs/Python/Python37-32/')],
+             pathex=['.', 'C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x86', os.path.dirname(sys.executable)],
              datas=[('circleguard/resources/','resources/'), ('circleguard/examples', 'examples/')],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
@@ -56,7 +57,7 @@ shortcut.Targetpath = abspath(abspath(".\dist\Circleguard_win_x86\Circleguard\Ci
 shortcut.save()
 
 print("Creating zip")
-os. chdir("./dist/")
+os.chdir("./dist/")
 zipf = zipfile.ZipFile('./Circleguard_win_x86.zip', 'w', zipfile.ZIP_DEFLATED)
 zipdir('./Circleguard_win_x86/', zipf)
 zipf.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyQt5<=5.12.2
+PyQt5==5.14.2
 circleguard==4.0.2
 packaging>=17.0
 slider>=0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyQt5==5.14.2
 circleguard==4.0.2
 packaging>=17.0
-slider>=0.2
+slider==0.2.1


### PR DESCRIPTION
See https://github.com/InvisibleSymbol/circleguard/releases/tag/v0.0.727 for an example release.

Can be triggered by sending `?release vX.Y.Z` in the discord, which will build the latest master and upload the files to a draft release with the tag `vX.Y.Z`. 
~~Currently only I can send that command but I will make it so anybody with the developer rule can send it.~~ should work for every dev now

Also requesting @tybug to check that the mac file works, I could only confirm the windows builds.

<sub><sup>The shortcut might also be broken on windows, investigating that</sub></sup>