### PR TITLE
add custom url scheme

### DIFF
--- a/circleguard/gui/circleguard_window.py
+++ b/circleguard/gui/circleguard_window.py
@@ -220,38 +220,46 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
         template_text = None
 
         if isinstance(result, StealResult):
+            circleguard_url = f"circleguard://m={result.replay1.map_id}&u={result.replay1.user_id}&u2={result.replay2.user_id}"
             label_text = get_setting("string_result_steal").format(ts=timestamp, similarity=result.similarity, r=result, r1=result.replay1, r2=result.replay2,
                                         earlier_replay_mods_short_name=result.earlier_replay.mods.short_name(), earlier_replay_mods_long_name=result.earlier_replay.mods.long_name(),
                                         later_replay_mods_short_name=result.later_replay.mods.short_name(), later_replay_mods_long_name=result.later_replay.mods.long_name())
             template_text = get_setting("template_steal").format(ts=timestamp, similarity=result.similarity, r=result, r1=result.replay1, r2=result.replay2,
                                         earlier_replay_mods_short_name=result.earlier_replay.mods.short_name(), earlier_replay_mods_long_name=result.earlier_replay.mods.long_name(),
-                                        later_replay_mods_short_name=result.later_replay.mods.short_name(), later_replay_mods_long_name=result.later_replay.mods.long_name())
+                                        later_replay_mods_short_name=result.later_replay.mods.short_name(), later_replay_mods_long_name=result.later_replay.mods.long_name(),
+                                        circleguard_url=circleguard_url)
             replays = [result.replay1, result.replay2]
 
         elif isinstance(result, RelaxResult):
+            circleguard_url = f"circleguard://m={result.replay.map_id}&u={result.replay.user_id}"
             label_text = get_setting("string_result_relax").format(ts=timestamp, ur=result.ur, r=result,
                                         replay=result.replay, mods_short_name=result.replay.mods.short_name(),
                                         mods_long_name=result.replay.mods.long_name())
             template_text = get_setting("template_relax").format(ts=timestamp, ur=result.ur, r=result,
                                         replay=result.replay, mods_short_name=result.replay.mods.short_name(),
-                                        mods_long_name=result.replay.mods.long_name())
+                                        mods_long_name=result.replay.mods.long_name(), circleguard_url=circleguard_url)
             replays = [result.replay]
         elif isinstance(result, CorrectionResult):
+            circleguard_url = f"circleguard://m={result.replay.map_id}&u={result.replay.user_id}"
             label_text = get_setting("string_result_correction").format(ts=timestamp, r=result, num_snaps=len(result.snaps), replay=result.replay,
                                         mods_short_name=result.replay.mods.short_name(), mods_long_name=result.replay.mods.long_name())
 
             snap_table = ("| Time (ms) | Angle (°) | Distance (px) |\n"
                             "| :-: | :-: | :-: |\n")
             for snap in result.snaps:
-                snap_table += "| {:.0f} | {:.2f} | {:.2f} |\n".format(snap.time, snap.angle, snap.distance)
+                url = f"circleguard://m={result.replay.map_id}&u={result.replay.user_id}&t={snap.time}"
+                snap_table += "| [{:.0f}]({}) | {:.2f} | {:.2f} |\n".format(snap.time, url, snap.angle, snap.distance)
             template_text = get_setting("template_correction").format(ts=timestamp, r=result, replay=result.replay, snap_table=snap_table,
-                                        mods_short_name=result.replay.mods.short_name(), mods_long_name=result.replay.mods.long_name())
+                                        mods_short_name=result.replay.mods.short_name(), mods_long_name=result.replay.mods.long_name(),
+                                        circleguard_url=circleguard_url)
             replays = [result.replay]
         elif isinstance(result, TimewarpResult):
+            circleguard_url = f"circleguard://m={result.replay.map_id}&u={result.replay.user_id}"
             label_text = get_setting("string_result_timewarp").format(ts=timestamp, r=result, replay=result.replay, frametime=result.frametime,
                                         mods_short_name=result.replay.mods.short_name(), mods_long_name=result.replay.mods.long_name())
             template_text = get_setting("template_timewarp").format(ts=timestamp, r=result, frametime=result.frametime,
-                                        mods_short_name=result.replay.mods.short_name(), mods_long_name=result.replay.mods.long_name())
+                                        mods_short_name=result.replay.mods.short_name(), mods_long_name=result.replay.mods.long_name(),
+                                        circleguard_url=circleguard_url)
             replays = [result.replay]
         elif isinstance(result, AnalysisResult):
             replays = result.replays
@@ -270,7 +278,7 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
         # remove info text if shown
         if not self.main_window.results_tab.results.info_label.isHidden():
             self.main_window.results_tab.results.info_label.hide()
-        self.main_window.results_tab.results.layout.insertWidget(0,result_widget)
+        self.main_window.results_tab.results.layout.insertWidget(0, result_widget)
 
     def add_url_analysis_result(self, result):
         self.main_window.main_tab.visualize_from_url(result)

--- a/circleguard/gui/circleguard_window.py
+++ b/circleguard/gui/circleguard_window.py
@@ -121,8 +121,10 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
     def url_scheme_called(self, url):
         # url is bytes, so decode back to str
         url = url.decode()
-        print(url)
-        # all urls are of the form circleguard://m=221777&u=12092800&t=10241
+        # windows appends an extra slash even if the original url didn't have 
+        # it, so remove it
+        url = url.strip("/")
+        # all urls are of the form circleguard://m=221777&u=2757689&t=150000
         map_id = re.compile(r"m=(.*?)(&|$)").search(url).group(1)
         user_id = re.compile(r"u=(.*?)(&|$)").search(url).group(1)
         timestamp = int(re.compile(r"t=(.*?)(&|$)").search(url).group(1))

--- a/circleguard/gui/circleguard_window.py
+++ b/circleguard/gui/circleguard_window.py
@@ -136,7 +136,6 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
         # open visualizer for the given map and user, and jump to the timestamp
         result = URLAnalysisResult([r], timestamp)
         self.main_window.main_tab.url_analysis_q.put(result)
-        pass
 
     def start_timer(self):
         timer = QTimer(self)
@@ -274,7 +273,7 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
         self.main_window.results_tab.results.layout.insertWidget(0,result_widget)
 
     def add_url_analysis_result(self, result):
-        self.main_window.main_tab.visualize(result.replays, result.replays[0].map_id, result, start_at=result.timestamp)
+        self.main_window.main_tab.visualize_from_url(result)
 
     def copy_to_clipboard(self, text):
         self.clipboard.setText(text)

--- a/circleguard/gui/main_tab.py
+++ b/circleguard/gui/main_tab.py
@@ -619,7 +619,6 @@ class MainTab(SingleLinkableSetting, QFrame):
                 self.add_url_analysis_result_signal.emit(result)
             except Empty:
                 pass
-        pass
         self.print_results_event.set()
 
     def visualize(self, replays, beatmap_id, result, start_at=0):
@@ -646,7 +645,7 @@ class MainTab(SingleLinkableSetting, QFrame):
         us a replay to visualize
         """
         map_id = result.replays[0].map_id
-        if self.visualizer and self.visualizer.replays and self.visualizer.replays[0].map_id == map_id:
+        if self.visualizer and self.visualizer.isVisible() and self.visualizer.replays and self.visualizer.replays[0].map_id == map_id:
             # pause even if we're currently playing - it's important that this
             # happens before seeking, or else the new frame won't correctly
             # display

--- a/circleguard/gui/main_tab.py
+++ b/circleguard/gui/main_tab.py
@@ -647,11 +647,13 @@ class MainTab(SingleLinkableSetting, QFrame):
         """
         map_id = result.replays[0].map_id
         if self.visualizer and self.visualizer.replays and self.visualizer.replays[0].map_id == map_id:
+            # pause even if we're currently playing - it's important that this
+            # happens before seeking, or else the new frame won't correctly
+            # display
+            self.visualizer.force_pause()
             # if we're visualizing the same replay that's in the url, just jump
             # to the new timestamp
             self.visualizer.seek_to(result.timestamp)
-            # pause even if we're currently playing
-            self.visualizer.force_pause()
             return
         # otherwise visualize as normal (which will close any existing
         # visualizers)

--- a/circleguard/gui/main_tab.py
+++ b/circleguard/gui/main_tab.py
@@ -639,7 +639,24 @@ class MainTab(SingleLinkableSetting, QFrame):
         if start_at != 0:
             self.visualizer.seek_to(start_at)
             self.visualizer.pause()
-
+    
+    def visualize_from_url(self, result):
+        """
+        called when our url scheme (circleguard://) was entered, giving
+        us a replay to visualize
+        """
+        map_id = result.replays[0].map_id
+        if self.visualizer and self.visualizer.replays and self.visualizer.replays[0].map_id == map_id:
+            # if we're visualizing the same replay that's in the url, just jump
+            # to the new timestamp
+            self.visualizer.seek_to(result.timestamp)
+            # pause even if we're currently playing
+            self.visualizer.force_pause()
+            return
+        # otherwise visualize as normal (which will close any existing
+        # visualizers)
+        self.visualize(result.replays, map_id, result, start_at=result.timestamp)
+        
 
 class TrackerLoader(Loader, QObject):
     """

--- a/circleguard/main.py
+++ b/circleguard/main.py
@@ -5,15 +5,15 @@ in other files.
 import sys
 import threading
 import traceback
-import fcntl
 import tempfile
 from pathlib import Path
 import socket
+import logging
 
 from PyQt5.QtWidgets import QApplication
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtCore import QObject, QSettings, QEvent, pyqtSignal
-import logging
+from PyQt5.QtCore import QSettings
+import portalocker
+from portalocker.exceptions import LockException
 
 from gui.circleguard_window import CircleguardWindow
 from settings import get_setting, set_setting
@@ -49,8 +49,8 @@ if not LOCK_FILE.exists():
 lock_file = open(LOCK_FILE, "r")
 
 try:
-    fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-except IOError:
+    portalocker.lock(lock_file, portalocker.LOCK_EX | portalocker.LOCK_NB)
+except LockException:
     # lock failed, a circleguard application is already running
     clientsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     clientsocket.connect(("localhost", SOCKET_PORT))

--- a/circleguard/main.py
+++ b/circleguard/main.py
@@ -154,4 +154,13 @@ def run_server_socket():
 thread = threading.Thread(target=run_server_socket)
 thread.start()
 
+# if we're opening for the first time from a url, the lock file won't be
+# locked, but we still want to visualize the replay in the url, so fake
+# a socket message identical to if the file had been locked
+if len(sys.argv) > 1:
+    clientsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    clientsocket.connect(("localhost", SOCKET_PORT))
+    clientsocket.send(sys.argv[1].encode())
+    clientsocket.close()
+    
 app.exec_()

--- a/circleguard/main.py
+++ b/circleguard/main.py
@@ -130,13 +130,22 @@ if not get_setting("ran"):
     welcome.show()
     set_setting("ran", True)
 
+def close_server_socket():
+    serversocket.close()
+
 app.aboutToQuit.connect(circleguard_gui.cancel_all_runs)
 app.aboutToQuit.connect(circleguard_gui.on_application_quit)
-# app.url_scheme_called.connect(circleguard_gui.url_scheme_called)
+# if we don't do this it hangs on cmd q
+app.aboutToQuit.connect(close_server_socket)
 
 def run_server_socket():
     while True:
-        connection, address = serversocket.accept()
+        try:
+            connection, _ = serversocket.accept()
+        except ConnectionAbortedError:
+            # happens when we close the serversocket when we quit, just silence
+            # the exception
+            return
         # arbitrary "large enough" byte receive size
         data = connection.recv(4096)
         circleguard_gui.url_scheme_called(data)

--- a/circleguard/main.py
+++ b/circleguard/main.py
@@ -83,8 +83,8 @@ def my_excepthook(exctype, value, tb):
 sys.excepthook = my_excepthook
 
 # sys.excepthook doesn't persist across threads
-# (http://bugs.python.org/issue1230540). This is a hacky workaround that overrides
-# the threading init method to use our excepthook.
+# (http://bugs.python.org/issue1230540). This is a hacky workaround that
+# overrides the threading init method to use our excepthook.
 # https://stackoverflow.com/a/31622038
 threading_init = threading.Thread.__init__
 def init(self, *args, **kwargs):
@@ -99,22 +99,6 @@ def init(self, *args, **kwargs):
     self.run = run_with_except_hook
 threading.Thread.__init__ = init
 
-
-# class URLHandlingApplication(QApplication):
-#     url_scheme_called = pyqtSignal(str) # url
-
-#     def __init__(self):
-#         super().__init__([])
-
-#     def event(self, event):
-#         with open("/Users/tybug/Desktop/a.txt", "w+") as f:
-#             f.write(str(event.type() == QEvent.FileOpen))
-#             f.write(str(event.type()) + "\n")
-#             f.write(str(QEvent.FileOpen))
-#             if event.type() == QEvent.FileOpen:
-#                 f.write(str(event.url))
-#                 self.url_scheme_called.emit(str(event.url))
-#         return super().event(event)
 
 app = QApplication([])
 app.setStyle("Fusion")

--- a/circleguard/settings.py
+++ b/circleguard/settings.py
@@ -166,6 +166,8 @@ DEFAULTS = {
                                 "\n\n"
                                 "{r.earlier_replay.username}'s replay (original): https://osu.ppy.sh/scores/osu/{r.earlier_replay.replay_id}/download"
                                 "\n\n"
+                                "open in circleguard: {circleguard_url}"
+                                "\n\n"
                                 "{r.similarity:.2f} similarity according to https://circleguard.dev/ (higher is less similar)"),
         "template_relax":      ("[osu!std] {r.replay.username} | Relax"
                                 "\n\n"
@@ -175,6 +177,8 @@ DEFAULTS = {
                                 "\n\n"
                                 "replay download: https://osu.ppy.sh/scores/osu/{r.replay.replay_id}/download"
                                 "\n\n"
+                                "open in circleguard: {circleguard_url}"
+                                "\n\n"
                                 "cvUR: {r.ur:.2f} according to https://circleguard.dev/"),
         "template_correction": ("[osu!std] {r.replay.username} | Aim Correction"
                                 "\n\n"
@@ -183,6 +187,8 @@ DEFAULTS = {
                                 "Map: https://osu.ppy.sh/b/{r.replay.map_id}"
                                 "\n\n"
                                 "replay download: https://osu.ppy.sh/scores/osu/{r.replay.replay_id}/download"
+                                "\n\n"
+                                "open in circleguard: {circleguard_url}"
                                 "\n\n"
                                 "Snaps according to https://circleguard.dev/:"
                                 "\n\n"
@@ -194,6 +200,8 @@ DEFAULTS = {
                                 "Map: https://osu.ppy.sh/b/{r.replay.map_id}"
                                 "\n\n"
                                 "replay download: https://osu.ppy.sh/scores/osu/{r.replay.replay_id}/download"
+                                "\n\n"
+                                "open in circleguard: {circleguard_url}"
                                 "\n\n"
                                 "{frametime:.1f} cv average frametime according to https://circleguard.dev/")
     },
@@ -384,7 +392,11 @@ FORCE_UPDATE = {
     "2.9.0": [
         "message_relax_found",
         "message_relax_found_display",
-        "string_result_relax"
+        "string_result_relax",
+        "template_steal",
+        "template_relax",
+        "template_correction",
+        "template_timewarp"
     ]
 }
 

--- a/circleguard/utils.py
+++ b/circleguard/utils.py
@@ -69,3 +69,8 @@ class DebugWidget(QFrame):
 class AnalysisResult():
     def __init__(self, replays):
         self.replays = replays
+
+class URLAnalysisResult():
+    def __init__(self, replays, timestamp):
+        self.replays = replays
+        self.timestamp = timestamp

--- a/circleguard/widgets.py
+++ b/circleguard/widgets.py
@@ -715,7 +715,7 @@ class FrametimeGraph(QFrame):
         super().__init__()
 
         frametimes = None
-        self.show_cv = get_setting("show_cv_frametimes_in_histogram")
+        self.show_cv = get_setting("frametime_graph_display") == "cv"
         self.conversion_factor = self._conversion_factor(replay)
         if isinstance(result, TimewarpResult):
             frametimes = result.frametimes

--- a/gui_mac.spec
+++ b/gui_mac.spec
@@ -52,16 +52,23 @@ exe = EXE(pyz,
           strip=False,
           upx=True,
           runtime_tmpdir=None,
-          console=False , icon='./resources/logo/logo_mac.icns')
+          console=False, icon='./resources/logo/logo_mac.icns')
 app = BUNDLE(exe,
-             name='Circleguard.app',
-             icon='./resources/logo/logo_mac.icns',
-             bundle_identifier=None,
-             info_plist={
-              'NSHighResolutionCapable': 'True',
-              'CFBundleShortVersionString': __version__
-             }
-       )
+            name='Circleguard.app',
+            icon='./resources/logo/logo_mac.icns',
+            bundle_identifier=None,
+            info_plist={
+                'NSHighResolutionCapable': 'True',
+                'CFBundleShortVersionString': __version__,
+                # register our ``circleguard://`` scheme
+                "CFBundleIdentifier": "circleguard",
+                "CFBundleURLTypes": [{
+                    "CFBundleURLName": "Circleguard",
+                    "CFBundleURLSchemes": [
+                        "circleguard"
+                    ]
+                }]
+            })
 
 print("Creating zip")
 zipf = zipfile.ZipFile('./Circleguard_osx.app.zip', 'w', zipfile.ZIP_DEFLATED)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ circlevis==0.1.3
 # which pins matplotlib at 3.0.3 (claiming that updating causes the hooks to fail).
 # I have not checked myself if updating matplotlib cuases the build to fail.
 matplotlib==3.0.3
+portalocker==1.7.1


### PR DESCRIPTION
This allows users to share urls which automatically open in circleguard and visualize the relevant replay(s). The following forms are supported:

* circleguard://m=221777&u=2757689&t=15000
* circleguard://m=221777&u=2757689
* circleguard://m=221777&u=2757689&u2=3219026

templates have also been updated to include a circleguard link to the replay.