### PR TITLE
lazy load all expensive modules

### DIFF
--- a/circleguard/gui/circleguard_window.py
+++ b/circleguard/gui/circleguard_window.py
@@ -6,10 +6,12 @@ import threading
 from datetime import datetime, timedelta
 import re
 
-from PyQt5.QtWidgets import *
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from circleguard import *
+from PyQt5.QtWidgets import (QMainWindow, QShortcut, QApplication,
+    QProgressBar, QLabel, QTextEdit)
+from PyQt5.QtCore import Qt, QObject, pyqtSignal, QTimer
+from PyQt5.QtGui import QIcon, QPalette, QColor, QKeySequence
+from circleguard import (ReplayMap, StealResult, RelaxResult, CorrectionResult,
+    TimewarpResult, Circleguard)
 from packaging import version
 import requests
 from requests import RequestException

--- a/circleguard/gui/circleguard_window.py
+++ b/circleguard/gui/circleguard_window.py
@@ -10,11 +10,11 @@ from PyQt5.QtWidgets import (QMainWindow, QShortcut, QApplication,
     QProgressBar, QLabel, QTextEdit)
 from PyQt5.QtCore import Qt, QObject, pyqtSignal, QTimer
 from PyQt5.QtGui import QIcon, QPalette, QColor, QKeySequence
-from circleguard import (ReplayMap, StealResult, RelaxResult, CorrectionResult,
-    TimewarpResult, Circleguard)
+# from circleguard import (ReplayMap, StealResult, RelaxResult, CorrectionResult,
+    # TimewarpResult, Circleguard)
 from packaging import version
-import requests
-from requests import RequestException
+# import requests
+# from requests import RequestException
 
 from settings import LinkableSetting, get_setting, set_setting, overwrite_config
 from widgets import WidgetCombiner, ResultW
@@ -121,6 +121,7 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
         super().mousePressEvent(event)
 
     def url_scheme_called(self, url):
+        from circleguard import ReplayMap, Circleguard
         # url is bytes, so decode back to str
         url = url.decode()
         # windows appends an extra slash even if the original url didn't have
@@ -153,7 +154,6 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
         # open visualizer for the given map and user, and jump to the timestamp
         result = URLAnalysisResult(replays, timestamp)
         self.main_window.main_tab.url_analysis_q.put(result)
-        print(self.main_window.main_tab.url_analysis_q.qsize())
 
     def start_timer(self):
         timer = QTimer(self)
@@ -195,6 +195,8 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
             self.update_label(self.get_version_update_str())
             return
         try:
+            import requests
+            from requests import RequestException
             # check for new version
             git_request = requests.get("https://api.github.com/repos/circleguard/circleguard/releases/latest").json()
             git_version = version.parse(git_request["name"])
@@ -228,6 +230,8 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
         self.progressbar.setRange(0, max_value)
 
     def add_result(self, result):
+        from circleguard import (StealResult, RelaxResult, CorrectionResult,
+            TimewarpResult)
         # this function right here could very well lead to some memory issues.
         # I tried to avoid leaving a reference to result's replays in this
         # method, but it's quite possible things are still not very clean.

--- a/circleguard/gui/gui.py
+++ b/circleguard/gui/gui.py
@@ -188,9 +188,7 @@ class SettingsTab(QFrame):
         self.info = QLabel(self)
         # multiple spaces get shrinked to one space in rich text mode
         # https://groups.google.com/forum/#!topic/qtcontribs/VDOQFUj-eIA
-        # TODO deal with circlecore version here
         self.info.setText(f"circleguard v{__version__}&nbsp;&nbsp;|&nbsp;&nbsp;"
-                          f"circlecore vUnknown&nbsp;&nbsp;|&nbsp;&nbsp;"
                           f"<a href=\"https://discord.gg/wj35ehD\">Discord</a>")
         self.info.setTextFormat(Qt.RichText)
         self.info.setTextInteractionFlags(Qt.TextBrowserInteraction)

--- a/circleguard/gui/gui.py
+++ b/circleguard/gui/gui.py
@@ -1,20 +1,14 @@
 import os
-import sys
-from pathlib import Path
 from queue import Queue, Empty
 from functools import partial
 import logging
-from logging.handlers import RotatingFileHandler
 import threading
-from datetime import datetime
-import math
-import time
 
-# TODO this might cause a performance hit (we only import * for convenience),
-# investigate
-from PyQt5.QtCore import *
-from PyQt5.QtWidgets import *
-from PyQt5.QtGui import *
+from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QTimer
+from PyQt5.QtWidgets import (QTabWidget, QVBoxLayout, QFrame, QScrollArea,
+    QLabel, QPushButton, QGridLayout, QSpacerItem, QSizePolicy, QMainWindow,
+    QTextEdit)
+from PyQt5.QtGui import QDesktopServices, QIcon
 
 from circleguard import Circleguard, ReplayPath
 from circleguard import __version__ as cg_version

--- a/circleguard/gui/gui.py
+++ b/circleguard/gui/gui.py
@@ -16,21 +16,16 @@ from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
 
-from circleguard import (Circleguard, set_options, Loader, NoInfoAvailableException,
-                        ReplayMap, ReplayPath, User, Map, Check, MapUser,
-                        StealResult, RelaxResult, CorrectionResult, Detect, Mod)
+from circleguard import Circleguard, ReplayPath
 from circleguard import __version__ as cg_version
-from circleguard.loadable import Loadable
 from circlevis import BeatmapInfo
-from slider import Library
 
-from utils import resource_path, delete_widget
+from utils import resource_path
 from widgets import (ResetSettings, WidgetCombiner, FolderChooser, Separator,
-                    ButtonWidget, OptionWidget, SliderBoxMaxInfSetting,
-                     SliderBoxSetting, BeatmapTest, LineEditSetting, EntryWidget, RunWidget,
-                     ComboboxSetting)
+    ButtonWidget, OptionWidget, SliderBoxMaxInfSetting, SliderBoxSetting,
+    BeatmapTest, LineEditSetting, EntryWidget, RunWidget, ComboboxSetting)
 
-from settings import get_setting, set_setting, overwrite_config, overwrite_with_config_settings, LinkableSetting, SingleLinkableSetting
+from settings import get_setting, set_setting, overwrite_config, overwrite_with_config_settings
 from .visualizer import CGVisualizer
 from .main_tab import MainTab
 from wizard import TutorialWizard

--- a/circleguard/gui/gui.py
+++ b/circleguard/gui/gui.py
@@ -10,9 +10,9 @@ from PyQt5.QtWidgets import (QTabWidget, QVBoxLayout, QFrame, QScrollArea,
     QTextEdit)
 from PyQt5.QtGui import QDesktopServices, QIcon
 
-from circleguard import Circleguard, ReplayPath
-from circleguard import __version__ as cg_version
-from circlevis import BeatmapInfo
+# from circleguard import Circleguard, ReplayPath
+# from circleguard import __version__ as cg_version
+# from circlevis import BeatmapInfo
 
 from utils import resource_path
 from widgets import (ResetSettings, WidgetCombiner, FolderChooser, Separator,
@@ -20,7 +20,7 @@ from widgets import (ResetSettings, WidgetCombiner, FolderChooser, Separator,
     BeatmapTest, LineEditSetting, EntryWidget, RunWidget, ComboboxSetting)
 
 from settings import get_setting, set_setting, overwrite_config, overwrite_with_config_settings
-from .visualizer import CGVisualizer
+from .visualizer import get_visualizer
 from .main_tab import MainTab
 from wizard import TutorialWizard
 from version import __version__
@@ -75,8 +75,8 @@ class VisualizeTab(QFrame):
         self.map_id = None
         self.q = Queue()
         self.replays = []
-        cache_path = get_setting("cache_dir") + "circleguard.db"
-        self.cg = Circleguard(get_setting("api_key"), cache_path)
+        # lazy loaded, see self.#cg
+        self._cg = None
         self.info = QLabel(self)
         self.info.setText("Visualizes Replays. Has theoretically support for an arbitrary amount of replays.")
         self.label_map_id = QLabel(self)
@@ -94,6 +94,14 @@ class VisualizeTab(QFrame):
         layout.addWidget(self.result_frame)
 
         self.setLayout(layout)
+
+    @property
+    def cg(self):
+        if not self._cg:
+            from circleguard import Circleguard
+            cache_path = get_setting("cache_dir") + "circleguard.db"
+            self._cg = Circleguard(get_setting("api_key"), cache_path)
+        return self._cg
 
     def start_timer(self):
         timer = QTimer(self)
@@ -127,6 +135,7 @@ class VisualizeTab(QFrame):
                 self._parse_replay(os.path.join(path, f))
 
     def _parse_replay(self, path):
+        from circleguard import ReplayPath
         replay = ReplayPath(path)
         self.cg.load(replay)
         if self.map_id is None or len(self.replays) == 0: # store map_id if nothing stored
@@ -179,8 +188,9 @@ class SettingsTab(QFrame):
         self.info = QLabel(self)
         # multiple spaces get shrinked to one space in rich text mode
         # https://groups.google.com/forum/#!topic/qtcontribs/VDOQFUj-eIA
+        # TODO deal with circlecore version here
         self.info.setText(f"circleguard v{__version__}&nbsp;&nbsp;|&nbsp;&nbsp;"
-                          f"circlecore v{cg_version}&nbsp;&nbsp;|&nbsp;&nbsp;"
+                          f"circlecore vUnknown&nbsp;&nbsp;|&nbsp;&nbsp;"
                           f"<a href=\"https://discord.gg/wj35ehD\">Discord</a>")
         self.info.setTextFormat(Qt.RichText)
         self.info.setTextInteractionFlags(Qt.TextBrowserInteraction)
@@ -270,9 +280,11 @@ class ScrollableSettingsWidget(QFrame):
     def visualize(self):
         if self.visualizer is not None:
             self.visualizer.close()
+        from circlevis import BeatmapInfo
         beatmap_info = BeatmapInfo(path=self.beatmaptest.file_chooser.path)
         # TODO pass the library we define in MainTab to CGVIsualizer,
         # probably will have to rework some things entirely
+        CGVisualizer = get_visualizer()
         self.visualizer = CGVisualizer(beatmap_info)
         self.visualizer.show()
 

--- a/circleguard/gui/main_tab.py
+++ b/circleguard/gui/main_tab.py
@@ -11,11 +11,13 @@ from lzma import LZMAError
 import traceback
 
 from PyQt5.QtCore import pyqtSignal, QObject, Qt
-from PyQt5.QtWidgets import QMessageBox, QFrame, QGridLayout, QComboBox, QTextEdit, QScrollArea, QPushButton, QApplication, QToolTip
+from PyQt5.QtWidgets import (QMessageBox, QFrame, QGridLayout, QComboBox,
+    QTextEdit, QScrollArea, QPushButton, QApplication, QToolTip)
 from PyQt5.QtGui import QTextCursor
-from circleguard import (Circleguard, ReplayDir, ReplayPath, Mod, UnknownAPIException,
-    NoInfoAvailableException, ReplayMap, Map, User, MapUser, Detect, Check,
-TimewarpResult, RelaxResult, CorrectionResult, StealResult, Loader)
+from circleguard import (Circleguard, ReplayDir, ReplayPath, Mod,
+    UnknownAPIException, NoInfoAvailableException, ReplayMap, Map, User,
+    MapUser, Detect, Check, TimewarpResult, RelaxResult, CorrectionResult,
+    StealResult, Loader)
 from slider import Library
 from circlevis import BeatmapInfo
 

--- a/circleguard/gui/visualizer.py
+++ b/circleguard/gui/visualizer.py
@@ -1,13 +1,16 @@
 from PyQt5.QtGui import QIcon
-from circlevis import Visualizer
 
 from utils import resource_path
 from settings import get_setting
 
-class CGVisualizer(Visualizer):
-    def __init__(self, beatmap_info, replays=[], events=[], library=None):
-        speeds = get_setting("speed_options")
-        start_speed = get_setting("default_speed")
-        paint_info = get_setting("visualizer_info")
-        super().__init__(beatmap_info, replays, events, library, speeds, start_speed, paint_info)
-        self.setWindowIcon(QIcon(resource_path("logo/logo.ico")))
+# necessary to avoid loading circlevis
+def get_visualizer():
+    from circlevis import Visualizer
+    class CGVisualizer(Visualizer):
+        def __init__(self, beatmap_info, replays=[], events=[], library=None):
+            speeds = get_setting("speed_options")
+            start_speed = get_setting("default_speed")
+            paint_info = get_setting("visualizer_info")
+            super().__init__(beatmap_info, replays, events, library, speeds, start_speed, paint_info)
+            self.setWindowIcon(QIcon(resource_path("logo/logo.ico")))
+    return CGVisualizer

--- a/circleguard/main.py
+++ b/circleguard/main.py
@@ -2,6 +2,8 @@
 This file exists to provide a top-level entry point so local imports will work
 in other files.
 """
+from datetime import datetime
+t1 = datetime.now()
 import sys
 import threading
 import traceback
@@ -19,9 +21,12 @@ from PyQt5.QtWidgets import QApplication
 import portalocker
 from portalocker.exceptions import LockException
 
+print(datetime.now() - t1)
 from gui.circleguard_window import CircleguardWindow
+print(datetime.now() - t1)
 from settings import get_setting, set_setting
 from wizard import CircleguardWizard
+print("done importing, total time taken: ", datetime.now() - t1)
 
 
 # semi randomly chosen
@@ -120,7 +125,6 @@ def init(self, *args, **kwargs):
     self.run = run_with_except_hook
 threading.Thread.__init__ = init
 
-
 app = QApplication([])
 app.setStyle("Fusion")
 app.setApplicationName("Circleguard")
@@ -167,4 +171,5 @@ if len(sys.argv) > 1:
     clientsocket.send(sys.argv[1].encode())
     clientsocket.close()
 
+print("execing app, total time taken: ", datetime.now() - t1)
 app.exec_()

--- a/circleguard/settings.py
+++ b/circleguard/settings.py
@@ -1,13 +1,11 @@
-import re
 import os
 from pathlib import Path
-from datetime import datetime, timedelta
 import abc
 import json
 import logging
 from functools import partial
 
-from PyQt5.QtCore import QSettings, QStandardPaths, pyqtSignal, QObject
+from PyQt5.QtCore import QSettings, QStandardPaths
 from packaging import version
 # it's tempting to use QSettings builtin ini file support instead of
 # configparser, but that doesn't let us write comments, which is rather

--- a/circleguard/widgets.py
+++ b/circleguard/widgets.py
@@ -694,8 +694,6 @@ class ResultW(QFrame):
 class FrametimeWindow(QMainWindow):
     def __init__(self, result, replay):
         super().__init__()
-        # delay matplotlib import until necessary (aka here) as a load time
-        # optimization
         # XXX make sure to import matplotlib after pyqt, so it knows to use that
         # and not re-import it.
         from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
@@ -717,7 +715,6 @@ class FrametimeGraph(QFrame):
     def __init__(self, result, replay):
         super().__init__()
         from circleguard import TimewarpResult
-
         from matplotlib.backends.backend_qt5agg import FigureCanvas # pylint: disable=no-name-in-module
         from matplotlib.figure import Figure
 

--- a/circleguard/widgets.py
+++ b/circleguard/widgets.py
@@ -4,16 +4,18 @@ from pathlib import Path
 from functools import partial
 import json
 
-from PyQt5.QtWidgets import (QWidget, QFrame, QGridLayout, QLabel, QLineEdit, QMessageBox,
-                             QSpacerItem, QSizePolicy, QSlider, QSpinBox, QFrame,
-                             QDoubleSpinBox, QFileDialog, QPushButton, QCheckBox, QComboBox, QVBoxLayout,
-                             QHBoxLayout, QMainWindow, QTableWidget, QTableWidgetItem, QAbstractItemView)
+from PyQt5.QtWidgets import (QWidget, QFrame, QGridLayout, QLabel, QLineEdit,
+    QMessageBox, QSpacerItem, QSizePolicy, QSlider, QSpinBox, QFrame,
+QDoubleSpinBox, QFileDialog, QPushButton, QCheckBox, QComboBox, QVBoxLayout,
+    QHBoxLayout, QMainWindow, QTableWidget, QTableWidgetItem, QAbstractItemView)
 from PyQt5.QtGui import QRegExpValidator, QIcon, QDrag
-from PyQt5.QtCore import QRegExp, Qt, QDir, QCoreApplication, pyqtSignal, QPoint, QMimeData
-from circleguard import Circleguard, TimewarpResult, Mod, Key
-import numpy as np
+from PyQt5.QtCore import (QRegExp, Qt, QDir, QCoreApplication, pyqtSignal,
+    QPoint, QMimeData)
+# from circleguard import Circleguard, TimewarpResult, Mod, Key
+# import numpy as np
 
-from settings import get_setting, reset_defaults, LinkableSetting, SingleLinkableSetting, set_setting
+from settings import (get_setting, reset_defaults, LinkableSetting,
+    SingleLinkableSetting, set_setting)
 from utils import resource_path, delete_widget, AnalysisResult
 
 SPACER = QSpacerItem(100, 0, QSizePolicy.Maximum, QSizePolicy.Minimum)
@@ -714,6 +716,7 @@ class FrametimeGraph(QFrame):
 
     def __init__(self, result, replay):
         super().__init__()
+        from circleguard import TimewarpResult
 
         from matplotlib.backends.backend_qt5agg import FigureCanvas # pylint: disable=no-name-in-module
         from matplotlib.figure import Figure
@@ -744,6 +747,7 @@ class FrametimeGraph(QFrame):
 
 
     def plot_normal(self, frametimes):
+        import numpy as np
         frametimes = self.conversion_factor * frametimes
         ax = self.canvas.figure.subplots()
 
@@ -754,6 +758,7 @@ class FrametimeGraph(QFrame):
 
     # adapted from https://matplotlib.org/examples/pylab_examples/broken_axis.html
     def plot_with_break(self, frametimes):
+        import numpy as np
         # gridspec_kw to make outlier plot smaller than the main one. https://stackoverflow.com/a/35881382
         ax1, ax2 = self.canvas.figure.subplots(1, 2, sharey=True, gridspec_kw={"width_ratios": [3, 1]})
         ax1.spines["right"].set_visible(False)
@@ -782,6 +787,7 @@ class FrametimeGraph(QFrame):
     # but the messy solution will work for now.
 
     def _conversion_factor(self, replay):
+        from circleguard import Mod
         if not self.show_cv:
             return 1
         if Mod.DT in replay.mods:
@@ -792,6 +798,7 @@ class FrametimeGraph(QFrame):
 
     @classmethod
     def get_frametimes(self, replay):
+        from circleguard import Circleguard
         cg = Circleguard(get_setting("api_key"))
         result = list(cg.timewarp_check(replay))
         return result[0].frametimes
@@ -809,6 +816,7 @@ class ReplayDataWindow(QMainWindow):
 class ReplayDataTable(QFrame):
     def __init__(self, replay):
         super().__init__()
+        from circleguard import Key
 
         table = QTableWidget()
         table.setColumnCount(4)
@@ -918,8 +926,9 @@ class SliderBoxSetting(SingleLinkableSetting, QFrame):
         slider = QSlider(Qt.Horizontal)
         slider.setFocusPolicy(Qt.ClickFocus)
         slider.setRange(0, max_)
-        # avoid errors when the setting is 2147483647 aka inf
-        slider.setValue(np.clip(0, max_, self.setting_value))
+        # max value of max_, avoid errors when the setting is 2147483647 aka inf
+        val = min(self.setting_value, max_)
+        slider.setValue(val)
         self.slider = slider
 
         spinbox = self.spin_box()

--- a/circleguard/widgets.py
+++ b/circleguard/widgets.py
@@ -10,11 +10,6 @@ from PyQt5.QtWidgets import (QWidget, QFrame, QGridLayout, QLabel, QLineEdit, QM
                              QHBoxLayout, QMainWindow, QTableWidget, QTableWidgetItem, QAbstractItemView)
 from PyQt5.QtGui import QRegExpValidator, QIcon, QDrag
 from PyQt5.QtCore import QRegExp, Qt, QDir, QCoreApplication, pyqtSignal, QPoint, QMimeData
-# XXX make sure to import matplotlib after pyqt, so it knows to use that and not
-# re-import it.
-# Not sure why pylint doesn't think FigureCanvas exists...
-from matplotlib.backends.backend_qt5agg import FigureCanvas, NavigationToolbar2QT # pylint: disable=no-name-in-module
-from matplotlib.figure import Figure
 from circleguard import Circleguard, TimewarpResult, Mod, Key
 import numpy as np
 
@@ -697,6 +692,12 @@ class ResultW(QFrame):
 class FrametimeWindow(QMainWindow):
     def __init__(self, result, replay):
         super().__init__()
+        # delay matplotlib import until necessary (aka here) as a load time
+        # optimization
+        # XXX make sure to import matplotlib after pyqt, so it knows to use that
+        # and not re-import it.
+        from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+
         self.setWindowTitle("Replay Frametime")
         self.setWindowIcon(QIcon(resource_path("logo/logo.ico")))
 
@@ -713,6 +714,9 @@ class FrametimeGraph(QFrame):
 
     def __init__(self, result, replay):
         super().__init__()
+
+        from matplotlib.backends.backend_qt5agg import FigureCanvas # pylint: disable=no-name-in-module
+        from matplotlib.figure import Figure
 
         frametimes = None
         self.show_cv = get_setting("frametime_graph_display") == "cv"


### PR DESCRIPTION
brings start time from ~1.2s to ~0.6s in a development environment. Haven't test what happens in a release instead of dev, but I imagine not much has changed - the gains there will come from trimming the excess modules pyinstaller is bundling, when we don't need them.