### PR TITLE
Add support for Qt High DPI Scaling

### DIFF
--- a/circleguard/main.py
+++ b/circleguard/main.py
@@ -16,6 +16,7 @@ except ImportError:
     pass
 
 from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import Qt
 import portalocker
 from portalocker.exceptions import LockException
 
@@ -147,6 +148,8 @@ def init(self, *args, **kwargs):
             sys.excepthook(*sys.exc_info())
     self.run = run_with_except_hook
 threading.Thread.__init__ = init
+
+QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
 
 app = QApplication([])
 app.setStyle("Fusion")


### PR DESCRIPTION
Should fix #54. Looks decent on my windows machine as shown below. Not tested on Unix.

4K @ 150% scaling **without Qt DPI Scaling**:
![unscaled](https://user-images.githubusercontent.com/29103029/111363870-77e36e80-8688-11eb-95f8-79521a51ce28.png)

4K @ 150% scaling **with Qt DPI Scaling**:
![scaled](https://user-images.githubusercontent.com/29103029/111363913-8598f400-8688-11eb-84f7-9667a41f93bf.png)
