### PR TITLE
fix startup crash when logging directory does not exist

### DIFF
--- a/circleguard/gui/circleguard_window.py
+++ b/circleguard/gui/circleguard_window.py
@@ -104,6 +104,10 @@ class CircleguardWindow(LinkableSetting, QMainWindow):
         handler.new_message.connect(self.log)
 
         log_dir = get_setting("log_dir")
+        try:
+            os.makedirs(log_dir)
+        except FileExistsError:
+            pass
         log_file = os.path.join(log_dir, "circleguard.log")
         # 1 mb max file size, with 3 rotating files.
         self.file_handler = RotatingFileHandler(log_file, maxBytes=10**6, backupCount=3)


### PR DESCRIPTION
When I tried to launch Circleguard for the first time (on Linux), it tried to create a log file in `~/.local/share/logs/`. However, while `~/.local/share/` does exist, there is no `./logs/` subdirectory in it.

This patch makes sure that upon launch, Circleguard will create any necessary directories needed to store logfiles.