### PR TITLE
Skip Unstable Rate investigations when there are less than two hits in a replay

### DIFF
--- a/circleguard/gui/main_tab.py
+++ b/circleguard/gui/main_tab.py
@@ -563,6 +563,11 @@ class MainTab(SingleLinkableSetting, QFrame):
                         _check_event(event)
                         # skip replays which have no map info
                         if cg.map_available(replay):
+                            # TODO: cache hits so they don't need to be calculated multiple times for a UR investigation
+                            if len(cg.hits(replay)) < 2:
+                                self.write_to_terminal_signal.emit(f"<div style='color:#ff5252'>{str(replay)} has one "
+                                    "or less hit. The replay has been skipped because of this. </div>")
+                                continue
                             try:
                                 ur = cg.ur(replay)
                             # Sometimes, a beatmap will have a bugged download where it returns an empty response

--- a/circleguard/gui/main_tab.py
+++ b/circleguard/gui/main_tab.py
@@ -564,9 +564,10 @@ class MainTab(SingleLinkableSetting, QFrame):
                         # skip replays which have no map info
                         if cg.map_available(replay):
                             # TODO: cache hits so they don't need to be calculated multiple times for a UR investigation
-                            if len(cg.hits(replay)) < 2:
-                                self.write_to_terminal_signal.emit(f"<div style='color:#ff5252'>{str(replay)} has one "
-                                    "or less hit. The replay has been skipped because of this. </div>")
+                            if len(cg.hits(replay)) < 3:
+                                self.write_to_terminal_signal.emit(f"<div style='color:#ff5252'>The replay {str(replay)} "
+                                    "hits less than 3 hit objects in the map, so its ur is unreliable. The replay has "
+                                    "been skipped because of this. </div>")
                                 continue
                             try:
                                 ur = cg.ur(replay)


### PR DESCRIPTION
Requested since replays with one hit will always be 0ur, meaning it will trigger a detection on these replays despite it being false (or inconclusive?)

Caching of hits may need to be looked into, this is a simple implementation of the skip, also warning the user.

Fixes: #173