### PR TITLE
Allow `SIGINT`s to close application while in Qt `exec()` loop

### DIFF
--- a/circleguard/main.py
+++ b/circleguard/main.py
@@ -2,6 +2,7 @@
 This file exists to provide a top-level entry point so local imports will work
 in other files.
 """
+import signal
 import sys
 import threading
 import traceback
@@ -263,6 +264,18 @@ def import_expensive_modules():
     # requests isn't that expensive, but might as well load it here anyway
     import requests
     # pylint: enable=unused-import
+
+# since the pyqt `app.exec()` (QApplication::exec()) function runs in a C++ binding,
+# python SIGINT signals are not handled due to python intercepting them and
+# throwing a `KeyboardInterrupt` so that it can cleanly exit. Only the next
+# python instruction will handle this exception, and since we are mainly
+# in C++ land it may take some time before the next python instruction runs
+# and the exception is thrown. So, lets handle the `SIGINT` signal globally,
+# instead of letting it be handled by the python runtime.
+# NOTE: This probably prevents `KeyboardInterrupt` exceptions from being thrown.
+# Fix and more details here:
+# https://stackoverflow.com/questions/5160577/ctrl-c-doesnt-work-with-pyqt
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 # everything would work fine if we didn't force import these modules now, but
 # the user would experience a potentially multi-second wait time whenever they


### PR DESCRIPTION
Something that was bothering me when trying to debug via Pycharm, and also when launching from the console (eg. `py ./main.py`).

I have added a comment to describe what it's doing, let me know if it needs changing!

Note that it will bypass the `KeyboardInterrupt` `SIGINT` way that python usually deals with `Ctrl+C`. So, if there are some things that cg is currently doing on app close using this, we might have to look at other options.

More info in this SO post: https://stackoverflow.com/questions/5160577/ctrl-c-doesnt-work-with-pyqt