### PR TITLE
Fix similarity checks never reporting below threshold for 2 osu!lazer replays

### DIFF
--- a/circleguard/gui/main_tab.py
+++ b/circleguard/gui/main_tab.py
@@ -647,17 +647,24 @@ class MainTab(SingleLinkableSetting, QFrame):
                 finally:
                     self.increment_progressbar_signal.emit(1)
 
+                replay_id = replay.replay_id
+
+                # HACK: lazer replays will encode replay ID as -1 since they don't have legacy score IDs
+                # we don't want any 2 lazer replays to skip similarity checks due to being "the same"
+                if replay_id == -1:
+                    replay_id = 0
+
                 # now that it's loaded, check if we've already seen the replay
                 # before. If so, remove it to prevent duplicate replays from
                 # being investigated (and potentially resulting in 0 sim).
-                if replay.replay_id in seen_replay_ids:
+                if replay_id in seen_replay_ids:
                     _remove_replay(replay)
                 # some replays have ``0`` for their replay id; we don't want to
                 # treat these as the same replay. Some replays might also have
                 # a null/None replay id? I don't think that should ever happen
                 # but just to be safe, also discount those here.
-                if replay.replay_id:
-                    seen_replay_ids.append(replay.replay_id)
+                if replay_id:
+                    seen_replay_ids.append(replay_id)
 
             if "Similarity" in run.enabled_investigations:
                 lc1.loaded = True


### PR DESCRIPTION
osu!lazer scores do not have legacy score IDs and it makes the choice to set score ID as `-1` when encoding the replay. This means that any 2 lazer replays being compared via GUI always get one of the 2 replays removed since `-1` makes its way into `seen_replay_ids`, meaning it never ends up doing any comparison.

This logic already handles the case `replay_id` is 0 or None, so treating `-1` in the same way seems to make most sense to me.

Have tested that this works.